### PR TITLE
Improve Arquero support.

### DIFF
--- a/src/table.js
+++ b/src/table.js
@@ -24,7 +24,7 @@ export function Table(
   align = alignof(align, data, columns);
 
   const N = lengthof(data); // total number of rows
-  let n = Math.floor(rows * 2); // number of currently-shown rows
+  let n = Math.min(N, Math.floor(rows * 2)); // number of currently-shown rows
   let currentSortHeader = null, currentReverse = false;
   let selected = new Set();
   let anchor = null, head = null;
@@ -175,7 +175,7 @@ export function Table(
     selected = new Set(Array.from(selected).sort(compare));
     root.scrollTo(0, 0);
     while (tbody.firstChild) tbody.firstChild.remove();
-    appendRows(0, n = Math.floor(rows * 2));
+    appendRows(0, n = Math.min(N, Math.floor(rows * 2)));
     anchor = head = null;
     reinput();
   }
@@ -188,7 +188,7 @@ export function Table(
 
   root.onscroll = () => {
     if (root.scrollHeight - root.scrollTop < 400 && n < N) {
-      appendRows(n, n += Math.floor(rows));
+      appendRows(n, n = Math.min(N, n + Math.floor(rows)));
     }
   };
 

--- a/src/table.js
+++ b/src/table.js
@@ -294,8 +294,8 @@ function lengthof(data) {
 }
 
 function columnsof(data) {
+  if (Array.isArray(data.columns)) return data.columns; // d3-dsv, FileAttachment
   if (typeof data.columnNames === "function") return data.columnNames(); // arquero
-  if (data.columns !== undefined) return data.columns; // d3-dsv, FileAttachment
   const columns = new Set();
   for (const row of data) {
     for (const name in row) {


### PR DESCRIPTION
Ref. https://github.com/uwdata/arquero/issues/89 /cc @jheer
Fixes #59.

If *data*.columnNames is a function, we now use that in favor of *data*.columns. This allows an Arquero table to “just work” with Table. Similarly, if *data*.numRows is a function, we use that in favor of *data*.size or *data*.length… though, it’d be my preference for Arquero’s Table to support a size getter so that it behaves more like a native JavaScript collection (e.g., Map or Set). PR for that: https://github.com/uwdata/arquero/pull/92

In addition, we now defer materializing *data* into an array until it’s necessary. In the common case we can lazily render rows in input-order, and we don’t need to materialize the full array. Materialization happens when sorting and when getting or setting the Table’s selection.