### PR TITLE
Downcase inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Observable Inputs** are lightweight user interface components — buttons, sliders, dropdowns, tables, and the like — to help you explore data and build interactive displays in [Observable notebooks](https://observablehq.com). Each input can be used as an [Observable view](https://observablehq.com/@observablehq/introduction-to-views). For example, to allow a number *x* to be manipulated by a slider:
 
 ```js
-viewof x = Range([0, 100])
+viewof x = Inputs.range([0, 100])
 ```
 
 Now you can reference the live value of *x* in any cell, *e.g.*:
@@ -40,22 +40,14 @@ Lastly, Inputs provides low-level utilities for more advanced usage:
 
 Observable Inputs are released under the [ISC license](./LICENSE) and depend only on [Hypertext Literal](https://github.com/observablehq/htl), our tagged template literal for safely generating dynamic HTML.
 
-## Installing
-
-In the near future, these components will be incorporated into the [Observable standard library](https://github.com/observablehq/stdlib) and available in notebooks by default. To use on Observable now:
-
-```js
-import {Button, Checkbox, Toggle, Radio, Range, Select, Text, Search, Table} from "@observablehq/inputs"
-```
-
 ## Inputs
 
-<a name="Button" href="#Button">#</a> <b>Button</b>(<i>content</i> = "≡", <i>options</i>) · [Source](./src/button.js), [Examples](https://observablehq.com/@observablehq/input-button)
+<a name="Button" href="#Button">#</a> Inputs.<b>button</b>(<i>content</i> = "≡", <i>options</i>) · [Source](./src/button.js), [Examples](https://observablehq.com/@observablehq/input-button)
 
 <img src="./img/button.png" alt="A Button labeled OK" width="640">
 
 ```js
-viewof clicks = Button("OK", {label: "Click me"})
+viewof clicks = Inputs.button("OK", {label: "Click me"})
 ```
 
 A Button emits an *input* event when you click it. Buttons may be used to trigger the evaluation of cells, say to restart an animation. The given *content*, either a string or an HTML element, is displayed within the button. If *content* is not specified, it defaults to “≡”, but a more meaningful value is strongly encouraged for usability.
@@ -63,13 +55,13 @@ A Button emits an *input* event when you click it. Buttons may be used to trigge
 By default, the value of a solitary Button (when *content* is a string or HTML) is how many times it has been clicked. The *reduce* function allows you to compute the new value of the Button when clicked, given the old value. For example, to set the value as the time of last click:
 
 ```js
-viewof time = Button("Refresh", {value: null, reduce: () => Date.now()})
+viewof time = Inputs.button("Refresh", {value: null, reduce: () => Date.now()})
 ```
 
 If *content* is an array or iterable, then multiple buttons will be generated. Each element in *content* should be a tuple [*contenti*, *reducei*], where *contenti* is the content for the given button (a string or HTML), and *reducei* is the function to call when that button is clicked. For example, to have a counter that you can increment, decrement, or reset to zero:
 
 ```js
-viewof counter = Button([
+viewof counter = Inputs.button([
   ["Increment", value => value + 1],
   ["Decrement", value => value - 1],
   ["Reset", () => 0]
@@ -85,12 +77,12 @@ The available *options* are:
 * *width* - the width of the input (not including the label).
 * *disabled* - whether input is disabled; defaults to false.
 
-<a name="Checkbox" href="#Checkbox">#</a> <b>Checkbox</b>(<i>data</i>, <i>options</i>) · [Source](./src/checkbox.js), [Examples](https://observablehq.com/@observablehq/input-checkbox)
+<a name="Checkbox" href="#Checkbox">#</a> Inputs.<b>checkbox</b>(<i>data</i>, <i>options</i>) · [Source](./src/checkbox.js), [Examples](https://observablehq.com/@observablehq/input-checkbox)
 
 <img src="./img/checkbox.png" alt="A multi-choice Checkbox input of flavors" width="640">
 
 ```js
-viewof flavor = Checkbox(["Salty", "Spicy", "Sour", "Umami"], {label: "Flavor"})
+viewof flavor = Inputs.checkbox(["Salty", "Spicy", "Sour", "Umami"], {label: "Flavor"})
 ```
 
 A Checkbox allows the user to choose any of a given set of values (any of the given elements in the iterable *data*). Unlike a [Select](#Select), a Checkbox’s choices are all visible up-front. The Checkbox’s value is an array of the elements from *data* that are currently selected.
@@ -98,7 +90,7 @@ A Checkbox allows the user to choose any of a given set of values (any of the gi
 The elements in *data* need not be strings; they can be anything. To customize display, optional *keyof* and *valueof* functions may be given; the result of the *keyof* function for each element in *data* is displayed to the user, while the result of the *valueof* function is exposed in the Checkbox’s value when selected. If *data* is a Map, the *keyof* function defaults to the map entry’s key (`([key]) => key`) and the *valueof* function defaults to the map entry’s value (`([, value]) => value`); otherwise, both *keyof* and *valueof* default to the identity function (`d => d`). For example, with [d3.group](https://github.com/d3/d3-array/blob/master/README.md#group):
 
 ```js
-viewof sportAthletes = Checkbox(d3.group(athletes, d => d.sport))
+viewof sportAthletes = Inputs.checkbox(d3.group(athletes, d => d.sport))
 ```
 
 Keys may be sorted and uniqued via the *sort* and *unique* options, respectively. Elements in *data* are formatted via an optional *format* function which has the same defaults as *keyof*. As with the *label* option, the *format* function may return either a string or an HTML element.
@@ -115,10 +107,10 @@ The available *options* are:
 * *value* - the initial value, an array; defaults to an empty array (no selection).
 * *disabled* - whether input is disabled, or the disabled values; defaults to false.
 
-<a name="Toggle" href="#Toggle">#</a> <b>Toggle</b>(<i>options</i>) · [Source](./src/checkbox.js), [Examples](https://observablehq.com/@observablehq/input-toggle)
+<a name="Toggle" href="#Toggle">#</a> Inputs.<b>toggle</b>(<i>options</i>) · [Source](./src/checkbox.js), [Examples](https://observablehq.com/@observablehq/input-toggle)
 
 ```js
-viewof mute = Toggle({label: "Mute"})
+viewof mute = Inputs.toggle({label: "Mute"})
 ```
 
 A Toggle is a solitary checkbox. By default, the Toggle’s value is whether the checkbox is checked (true or false); a *values* = [*on*, *off*] option can be specified to toggle between two arbitrary values.
@@ -130,12 +122,12 @@ The available *options* are:
 * *value* - the initial value; defaults to the second value (false).
 * *disabled* - whether input is disabled; defaults to false.
 
-<a name="Radio" href="#Radio">#</a> <b>Radio</b>(<i>data</i>, <i>options</i>) · [Source](./src/checkbox.js), [Examples](https://observablehq.com/@observablehq/input-radio)
+<a name="Radio" href="#Radio">#</a> Inputs.<b>radio</b>(<i>data</i>, <i>options</i>) · [Source](./src/checkbox.js), [Examples](https://observablehq.com/@observablehq/input-radio)
 
 <img src="./img/radio.png" alt="A single-choice Radio input of colors" width="640">
 
 ```js
-viewof color = Radio(["red", "green", "blue"]), {label: "Color"})
+viewof color = Inputs.radio(["red", "green", "blue"]), {label: "Color"})
 ```
 
 A Radio allows the user to choose one of a given set of values. Unlike a [Select](#Select), a Radio’s choices are all visible up-front. The Radio’s value is an element from *data*, or null if no choice has been made.
@@ -143,7 +135,7 @@ A Radio allows the user to choose one of a given set of values. Unlike a [Select
 The elements in *data* need not be strings; they can be anything. To customize display, optional *keyof* and *valueof* functions may be given; the result of the *keyof* function for each element in *data* is displayed to the user, while the result of the *valueof* function is exposed as the Radio’s value when selected. If *data* is a Map, the *keyof* function defaults to the map entry’s key (`([key]) => key`) and the *valueof* function defaults to the map entry’s value (`([, value]) => value`); otherwise, both *keyof* and *valueof* default to the identity function (`d => d`). For example, with [d3.group](https://github.com/d3/d3-array/blob/master/README.md#group):
 
 ```js
-viewof sportAthletes = Radio(d3.group(athletes, d => d.sport))
+viewof sportAthletes = Inputs.radio(d3.group(athletes, d => d.sport))
 ```
 
 Keys may be sorted and uniqued via the *sort* and *unique* options, respectively. Elements in *data* are formatted via an optional *format* function which has the same defaults as *keyof*. As with the *label* option, the *format* function may return either a string or an HTML element.
@@ -160,12 +152,12 @@ The available *options* are:
 * *value* - the initial value; defaults to null (no selection).
 * *disabled* - whether input is disabled, or the disabled values; defaults to false.
 
-<a name="Range" href="#Range">#</a> <b>Range</b>([<i>min</i>, <i>max</i>] = [0, 1], <i>options</i>) · [Source](./src/range.js), [Examples](https://observablehq.com/@observablehq/input-range)
+<a name="Range" href="#Range">#</a> Inputs.<b>range</b>([<i>min</i>, <i>max</i>] = [0, 1], <i>options</i>) · [Source](./src/range.js), [Examples](https://observablehq.com/@observablehq/input-range)
 
 <img src="./img/range.png" alt="A Range input of intensity, a number between 0 and 100" width="640">
 
 ```js
-viewof intensity = Range([0, 100], {step: 1, label: "Intensity"})
+viewof intensity = Inputs.range([0, 100], {step: 1, label: "Intensity"})
 ```
 
 A Range input specifies a number between the given *min* and *max* (inclusive). This number can be adjusted roughly with a slider, or precisely by typing a number.
@@ -188,12 +180,12 @@ The *format* function should return a string value that is compatible with nativ
 
 If a *transform* function is specified, an inverse transform function *invert* is strongly recommended. If *invert* is not provided, the Range will fallback to Newton’s method, but this may be slow or inaccurate. Passing Math.sqrt, Math.log, or Math.exp as a *transform* will automatically supply the corresponding *invert*. If *min* is greater than *max*, *i.e.* if the extent is inverted, then *transform* and *invert* will default to `value => -value`.
 
-<a name="Search" href="#Search">#</a> <b>Search</b>(<i>data</i>, <i>options</i>) · [Source](./src/search.js), [Examples](https://observablehq.com/@observablehq/input-search)
+<a name="Search" href="#Search">#</a> Inputs.<b>search</b>(<i>data</i>, <i>options</i>) · [Source](./src/search.js), [Examples](https://observablehq.com/@observablehq/input-search)
 
 <img src="./img/search.png" alt="A Search input over a tabular dataset of athletes" width="640">
 
 ```js
-viewof foundAthletes = Search(athletes, {label: "Athletes"})
+viewof foundAthletes = Inputs.search(athletes, {label: "Athletes"})
 ```
 
 A Search input allows freeform, full-text search of an in-memory tabular dataset or an iterable (column) of values using a simple query parser. It is often used in conjunction with a [Table](#Table). The value of a Search is an array of elements from the iterable *data* that match the current query. If the query is currently empty, the search input’s value is all elements in *data*.
@@ -201,13 +193,13 @@ A Search input allows freeform, full-text search of an in-memory tabular dataset
 A Search input can work with either tabular data (an array of objects) or a single column (an array of strings). When searching tabular input, all properties on each object in *data* are searched by default, but you can limit the search to a specific set of properties using the *column* option. For example, to only search the “sport” and “nationality” column:
 
 ```js
-viewof foundAthletes = Search(athletes, {label: "Athletes", columns: ["sport", "nationality"]})
+viewof foundAthletes = Inputs.search(athletes, {label: "Athletes", columns: ["sport", "nationality"]})
 ```
 
 For example, to search U.S. state names:
 
 ```js
-viewof state = Search(["Alabama", "Alaska", "Arizona", "Arkansas", "California", …], {label: "State"})
+viewof state = Inputs.search(["Alabama", "Alaska", "Arizona", "Arkansas", "California", …], {label: "State"})
 ```
 
 The available *options* are:
@@ -227,15 +219,15 @@ The available *options* are:
 
 If a *filter* function is specified, it is invoked whenever the query changes; the function it returns is then passed each element from *data*, along with its zero-based index, and should return a truthy value if the given element matches the query. The default filter splits the current query into space-separated tokens and checks that each token matches the beginning of at least one string in the data’s columns, case-insensitive. For example, the query [hello world] will match the string “Worldwide Hello Services” but not “hello”.
 
-<a name="Select" href="#Select">#</a> <b>Select</b>(<i>data</i>, <i>options</i>) · [Source](./src/select.js), [Examples](https://observablehq.com/@observablehq/input-select)
+<a name="Select" href="#Select">#</a> Inputs.<b>select</b>(<i>data</i>, <i>options</i>) · [Source](./src/select.js), [Examples](https://observablehq.com/@observablehq/input-select)
 
 <img src="./img/select.png" alt="A Select input asking to choose a t-shirt size" width="640">
 
 ```js
-viewof size = Select(["Small", "Medium", "Large"], {label: "Size"})
+viewof size = Inputs.select(["Small", "Medium", "Large"], {label: "Size"})
 ```
 ```js
-viewof inks = Select(["cyan", "magenta", "yellow", "black"], {multiple: true, label: "Inks"})
+viewof inks = Inputs.select(["cyan", "magenta", "yellow", "black"], {multiple: true, label: "Inks"})
 ```
 
 A Select allows the user to choose one of a given set of values (one of the given elements in the iterable *data*); or, if desired, multiple values may be chosen. Unlike a [Radio](#Radio), only one (or a few) choices are visible up-front, affording a compact display even when many options are available. If multiple choice is allowed via the *multiple* option, the Select’s value is an array of the elements from *data* that are currently selected; if single choice is required, the Select’s value is an element from *data*, or null if no choice has been made.
@@ -243,7 +235,7 @@ A Select allows the user to choose one of a given set of values (one of the give
 The elements in *data* need not be strings; they can be anything. To customize display, optional *keyof* and *valueof* functions may be given; the result of the *keyof* function for each element in *data* is displayed to the user, while the result of the *valueof* function is exposed as the Select’s value when selected. If *data* is a Map, the *keyof* function defaults to the map entry’s key (`([key]) => key`) and the *valueof* function defaults to the map entry’s value (`([, value]) => value`); otherwise, both *keyof* and *valueof* default to the identity function (`d => d`). For example, with [d3.group](https://github.com/d3/d3-array/blob/master/README.md#group):
 
 ```js
-viewof sportAthletes = Select(d3.group(athletes, d => d.sport))
+viewof sportAthletes = Inputs.select(d3.group(athletes, d => d.sport))
 ```
 
 Keys may be sorted and uniqued via the *sort* and *unique* options, respectively. Elements in *data* are formatted via an optional *format* function which has the same defaults as *keyof*. While the *label* option may be either a string or an HTML element, the *format* function must return a string (unlike a Radio).
@@ -263,7 +255,7 @@ The available *options* are:
 * *width* - the width of the input (not including the label).
 * *disabled* - whether input is disabled, or the disabled values; defaults to false.
 
-<a name="Table" href="#Table">#</a> <b>Table</b>(<i>data</i>, <i>options</i>) · [Source](./src/table.js), [Examples](https://observablehq.com/@observablehq/input-table)
+<a name="Table" href="#Table">#</a> Inputs.<b>table</b>(<i>data</i>, <i>options</i>) · [Source](./src/table.js), [Examples](https://observablehq.com/@observablehq/input-table)
 
 <img src="./img/table.png" alt="A Table input showing rows of Olympic athletes" width="988">
 
@@ -294,12 +286,12 @@ The available *options* are:
 
 If *width* is “auto”, the table width will be based on the table contents; note that this may cause the table to resize as rows are lazily rendered.
 
-<a name="Text" href="#Text">#</a> <b>Text</b>(<i>options</i>) · [Source](./src/text.js), [Examples](https://observablehq.com/@observablehq/input-text)
+<a name="Text" href="#Text">#</a> Inputs.<b>text</b>(<i>options</i>) · [Source](./src/text.js), [Examples](https://observablehq.com/@observablehq/input-text)
 
 <img src="./img/text.png" alt="A Text input asking to enter your name" width="640">
 
 ```js
-viewof name = Text({label: "Name", placeholder: "Enter your name"})
+viewof name = Inputs.text({label: "Name", placeholder: "Enter your name"})
 ```
 
 A Text allows freeform single-line text input. For example, a Text might be used to allow the user to enter a search query. (See also [Search](#Search).) By default, a Text will report its value immediately on input. If more deliberate behavior is desired, say if the input will trigger an expensive computation or remote API, the *submit* option can be set to true to wait until a button is clicked or the Enter key is pressed.
@@ -324,12 +316,12 @@ The available *options* are:
 
 If *validate* is not defined, [*text*.checkValidity](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-checkvalidity) is used. While the input is not considered valid, changes to the input will not be reported.
 
-<a name="Textarea" href="#Textarea">#</a> <b>Textarea</b>(<i>options</i>) · [Source](./src/textarea.js)
+<a name="Textarea" href="#Textarea">#</a> Inputs.<b>textarea</b>(<i>options</i>) · [Source](./src/textarea.js)
 
 <img src="./img/textarea.png" alt="A Textarea asking for your biography" width="660">
 
 ```js
-viewof bio = Textarea({label: "Biography", placeholder: "Tell us a little about yourself…"})
+viewof bio = Inputs.textarea({label: "Biography", placeholder: "Tell us a little about yourself…"})
 ```
 
 A Textarea allows multi-line freeform text input. By default, a Textarea will report its value immediately on input. If more deliberate behavior is desired, the *submit* option can be set to true to wait until a button is clicked or Command-Enter is pressed.
@@ -356,21 +348,21 @@ If *validate* is not defined, [*text*.checkValidity](https://html.spec.whatwg.or
 
 ## Utilities
 
-<a name="Input" href="#Input">#</a> <b>Input</b>(<i>value</i>) · [Source](./src/input.js), [Examples](https://observablehq.com/@observablehq/synchronized-inputs)
+<a name="Input" href="#Input">#</a> Inputs.<b>input</b>(<i>value</i>) · [Source](./src/input.js), [Examples](https://observablehq.com/@observablehq/synchronized-inputs)
 
 Returns an [EventTarget](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget) with the specified *value*. This is typically used in conjunction with [bind](#bind) to synchronize multiple inputs, with the Input being the primary state store. An Input is similar to a [mutable](https://observablehq.com/@observablehq/introduction-to-mutable-state), except that it allows listeners.
 
-<a name="bind" href="#bind">#</a> <b>bind</b>(<i>target</i>, <i>source</i>, <i>invalidation</i>) · [Source](./src/bind.js), [Examples](https://observablehq.com/@observablehq/synchronized-inputs)
+<a name="bind" href="#bind">#</a> Inputs.<b>bind</b>(<i>target</i>, <i>source</i>, <i>invalidation</i>) · [Source](./src/bind.js), [Examples](https://observablehq.com/@observablehq/synchronized-inputs)
 
 The bind function allows a *target* input to be bound to a *source* input, synchronizing the two: interaction with the *source* input will propagate to the *target* input and *vice versa*.
 
 The relationship between *target* and *source* is not symmetric: the *target* input should be considered a dependant of the *source* input, and if desired, only the *source* should be declared an Observable view. For example:
 
 ```js
-viewof i = Input(42) // the “primary” input
+viewof i = Inputs.input(42) // the “primary” input
 ```
 ```js
-bind(Range([0, 100]), viewof i) // a bound “secondary” input
+Inputs.bind(Inputs.range([0, 100]), viewof i) // a bound “secondary” input
 ```
 
 When the *target* emits a type-appropriate event, the *target*’s type-appropriate value will be applied to the *source* and a type-appropriate event will be dispatched on the *source*; when the *source* emits a type-appropriate event, the *source*’s type-appropriate value will be applied to the *target*, but *no event will be dispatched*, avoiding an infinite loop.
@@ -379,26 +371,26 @@ The type-appropriate event is a *click* event for buttons and submit inputs, a *
 
 If *invalidation* is specified, it is a promise; when the promise resolves, the target will stop listening to the source. If *invalidation* is not specified, it defaults to the [disposal promise](#disposal) on the specified *target*. Note that source will remain listening to the target, however, until the target is garbage-collected.
 
-<a name="disposal" href="#disposal">#</a> <b>disposal</b>(<i>element</i>) · [Source](./src/disposal.js)
+<a name="disposal" href="#disposal">#</a> Inputs.<b>disposal</b>(<i>element</i>) · [Source](./src/disposal.js)
 
 The disposal promise is a heuristic for detecting when an input has been removed from the DOM, say to detach synchronized inputs. It is used by [bind](#bind) by default as the invalidation promise, but is exported here for convenience.
 
-<a name="searchFilter" href="#searchFilter">#</a> <b>searchFilter</b>(<i>query</i>) · [Source](./src/search.js)
+<a name="searchFilter" href="#searchFilter">#</a> Inputs.<b>searchFilter</b>(<i>query</i>) · [Source](./src/search.js)
 
 The default query parser used by [Search](#Search).
 
-<a name="formatLocaleAuto" href="#formatLocaleAuto">#</a> <b>formatLocaleAuto</b>(<i>locale</i> = "en") · [Source](./src/format.js)
+<a name="formatLocaleAuto" href="#formatLocaleAuto">#</a> Inputs.<b>formatLocaleAuto</b>(<i>locale</i> = "en") · [Source](./src/format.js)
 
 If *value* is null, returns the empty string; if *value* is a number, calls [formatLocaleNumber](#formatLocaleNumber) if *value* is a date, calls [formatDate](#formatDate); otherwise coerces *value* to a string.
 
-<a name="formatLocaleNumber" href="#formatLocaleNumber">#</a> <b>formatLocaleNumber</b>(<i>locale</i> = "en) · [Source](./src/format.js)
+<a name="formatLocaleNumber" href="#formatLocaleNumber">#</a> Inputs.<b>formatLocaleNumber</b>(<i>locale</i> = "en) · [Source](./src/format.js)
 
 The default number formatter used by [Table](#Table).
 
-<a name="formatTrim" href="#formatTrim">#</a> <b>formatTrim</b>(<i>number</i>) · [Source](./src/format.js)
+<a name="formatTrim" href="#formatTrim">#</a> Inputs.<b>formatTrim</b>(<i>number</i>) · [Source](./src/format.js)
 
 The default number formatter used by [Range](#Range).
 
-<a name="formatDate" href="#formatDate">#</a> <b>formatDate</b>(<i>date</i>) · [Source](./src/format.js)
+<a name="formatDate" href="#formatDate">#</a> Inputs.<b>formatDate</b>(<i>date</i>) · [Source](./src/format.js)
 
 The default date formatter used by [Table](#Table).

--- a/src/button.js
+++ b/src/button.js
@@ -4,7 +4,7 @@ import {dispatchInput, preventDefault} from "./event.js";
 import {identity} from "./identity.js";
 import {maybeLabel} from "./label.js";
 
-export function Button(content = "≡", {
+export function button(content = "≡", {
   label = "",
   value,
   reduce,

--- a/src/checkbox.js
+++ b/src/checkbox.js
@@ -22,11 +22,11 @@ function createCheckbox(multiple, type) {
   });
 }
 
-export const Radio = createCheckbox(false, "radio");
+export const radio = createCheckbox(false, "radio");
 
-export const Checkbox = createCheckbox(true, "checkbox");
+export const checkbox = createCheckbox(true, "checkbox");
 
-export function Toggle({label, value, values, disabled} = {}) {
+export function toggle({label, value, values, disabled} = {}) {
   const input = html`<input class=__ns__-input type=checkbox name=input disabled=${disabled}>`;
   const form = html`<form class="__ns__ __ns__-toggle">${maybeLabel(label, input)}${input}`;
   Object.defineProperty(form, "value", {

--- a/src/chooser.js
+++ b/src/chooser.js
@@ -8,7 +8,7 @@ const first = ([x]) => x;
 const second = ([, x]) => x;
 
 export function createChooser({multiple: fixedMultiple, render, selectedIndexes, select}) {
-  return function Chooser(data, {
+  return function chooser(data, {
     locale,
     keyof = data instanceof Map ? first : identity,
     valueof = data instanceof Map ? second : identity,

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,14 @@
 import "./style.css";
 
-export {Button} from "./button.js";
-export {Checkbox, Radio, Toggle} from "./checkbox.js";
-export {Range} from "./range.js";
-export {Search, searchFilter} from "./search.js";
-export {Select} from "./select.js";
-export {Table} from "./table.js";
-export {Text} from "./text.js";
-export {Textarea} from "./textarea.js";
-export {Input} from "./input.js";
+export {button} from "./button.js";
+export {checkbox, radio, toggle} from "./checkbox.js";
+export {range} from "./range.js";
+export {search, searchFilter} from "./search.js";
+export {select} from "./select.js";
+export {table} from "./table.js";
+export {text} from "./text.js";
+export {textarea} from "./textarea.js";
+export {input} from "./input.js";
 export {bind} from "./bind.js";
 export {disposal} from "./disposal.js";
 export {formatDate, formatLocaleAuto, formatLocaleNumber, formatTrim} from "./format.js";

--- a/src/input.js
+++ b/src/input.js
@@ -1,5 +1,5 @@
-export function Input(value) {
-  const input = new EventTarget();
-  input.value = value;
-  return input;
+export function input(value) {
+  const target = new EventTarget();
+  target.value = value;
+  return target;
 }

--- a/src/range.js
+++ b/src/range.js
@@ -7,7 +7,7 @@ import {maybeLabel} from "./label.js";
 
 const epsilon = 1e-6;
 
-export function Range([min, max] = [0, 1], {
+export function range([min, max] = [0, 1], {
   format = formatTrim,
   transform,
   invert,

--- a/src/search.js
+++ b/src/search.js
@@ -6,7 +6,7 @@ import {preventDefault} from "./event.js";
 import {formatLocaleNumber, localize, stringify} from "./format.js";
 import {maybeLabel} from "./label.js";
 
-export function Search(data, {
+export function search(data, {
   locale,
   format = formatResults(locale), // length format
   label,

--- a/src/select.js
+++ b/src/select.js
@@ -4,7 +4,7 @@ import {maybeWidth} from "./css.js";
 import {stringify} from "./format.js";
 import {maybeLabel} from "./label.js";
 
-export const Select = createChooser({
+export const select = createChooser({
   render(data, index, selected, disabled, {format, multiple, size, label, width}) {
     const select = html`<select class=__ns__-input disabled=${disabled === true} multiple=${multiple} size=${size} name=input>
       ${index.map(i => html`<option value=${i} disabled=${typeof disabled === "function" ? disabled(i) : false} selected=${selected(i)}>${stringify(format(data[i], i, data))}`)}

--- a/src/table.js
+++ b/src/table.js
@@ -8,7 +8,7 @@ import {defined, ascending, descending} from "./sort.js";
 
 const rowHeight = 22;
 
-export function Table(
+export function table(
   data,
   {
     columns, // array of column names

--- a/src/text.js
+++ b/src/text.js
@@ -49,7 +49,7 @@ export function createText(form, input, {value = "", submit, validate = checkVal
   });
 }
 
-export function Text({
+export function text({
   label,
   type = "text",
   placeholder,

--- a/src/textarea.js
+++ b/src/textarea.js
@@ -3,7 +3,7 @@ import {maybeWidth} from "./css.js";
 import {maybeLabel} from "./label.js";
 import {createText} from "./text.js";
 
-export function Textarea({
+export function textarea({
   label,
   placeholder,
   spellcheck,

--- a/test/bind-test.js
+++ b/test/bind-test.js
@@ -1,9 +1,9 @@
-import {bind} from "@observablehq/inputs";
+import * as Inputs from "@observablehq/inputs";
 import tape from "./jsdom.js";
 
-tape("bind(button, button) dispatches click events", test => {
+tape("Inputs.bind(button, button) dispatches click events", test => {
   const b1 = document.createElement("button");
-  const b2 = bind(document.createElement("button"), b1, new Promise(() => {}));
+  const b2 = Inputs.bind(document.createElement("button"), b1, new Promise(() => {}));
   let clicked = false;
   b1.addEventListener("click", () => void (clicked = true), {once: true});
   b2.dispatchEvent(new Event("click"));

--- a/test/checkbox-test.js
+++ b/test/checkbox-test.js
@@ -1,8 +1,8 @@
-import {Checkbox} from "@observablehq/inputs";
+import * as Inputs from "@observablehq/inputs";
 import tape from "./jsdom.js";
 
-tape("Checkbox([]) handles empty options", test => {
-  const r = Checkbox([]);
+tape("Inputs.checkbox([]) handles empty options", test => {
+  const r = Inputs.checkbox([]);
   test.deepEqual(r.value, []);
   test.strictEqual(r.value, r.value);
   r.value = ["red"];
@@ -10,8 +10,8 @@ tape("Checkbox([]) handles empty options", test => {
   test.strictEqual(r.value, r.value);
 });
 
-tape("Checkbox([value]) handles singular option", test => {
-  const r = Checkbox(["red"]);
+tape("Inputs.checkbox([value]) handles singular option", test => {
+  const r = Inputs.checkbox(["red"]);
   test.deepEqual(r.value, []);
   test.strictEqual(r.value, r.value);
   r.value = ["blue"];

--- a/test/inputs/buttons.js
+++ b/test/inputs/buttons.js
@@ -1,30 +1,30 @@
-import {Button} from "@observablehq/inputs";
+import * as Inputs from "@observablehq/inputs";
 import {html} from "htl";
 
 export async function button() {
-  return Button();
+  return Inputs.button();
 }
 
 export async function buttonContent() {
-  return Button("dollars&pounds");
+  return Inputs.button("dollars&pounds");
 }
 
 export async function buttonContentHtml() {
-  return Button(html.fragment`<b>Click</b> me`);
+  return Inputs.button(html.fragment`<b>Click</b> me`);
 }
 
 export async function buttonLabel() {
-  return Button("OK", {label: "dollars&pounds"});
+  return Inputs.button("OK", {label: "dollars&pounds"});
 }
 
 export async function buttonLabelHtml() {
-  return Button("OK", {label: html`<b>intensity</b>`});
+  return Inputs.button("OK", {label: html`<b>intensity</b>`});
 }
 
 export async function buttonDisabled() {
-  return Button("OK", {disabled: true});
+  return Inputs.button("OK", {disabled: true});
 }
 
 export async function buttonWidth() {
-  return Button("OK", {width: "20em"});
+  return Inputs.button("OK", {width: "20em"});
 }

--- a/test/inputs/checkboxes.js
+++ b/test/inputs/checkboxes.js
@@ -1,78 +1,78 @@
-import {Checkbox} from "@observablehq/inputs";
+import * as Inputs from "@observablehq/inputs";
 import {html} from "htl";
 
 export async function checkbox() {
-  return Checkbox(["red", "green", "blue"]);
+  return Inputs.checkbox(["red", "green", "blue"]);
 }
 
 export async function checkboxFormat() {
-  return Checkbox(["red", "green", "blue"], {format: x => x.toUpperCase()});
+  return Inputs.checkbox(["red", "green", "blue"], {format: x => x.toUpperCase()});
 }
 
 export async function checkboxLabel() {
-  return Checkbox(["red", "green", "blue"], {label: "dollars&pounds"});
+  return Inputs.checkbox(["red", "green", "blue"], {label: "dollars&pounds"});
 }
 
 export async function checkboxLabelHtml() {
-  return Checkbox(["red", "green", "blue"], {label: html`<b>color</b>`});
+  return Inputs.checkbox(["red", "green", "blue"], {label: html`<b>color</b>`});
 }
 
 export async function checkboxMap() {
-  return Checkbox(new Map([["red", "#f00"], ["green", "#0f0"], ["blue", "#00f"]]));
+  return Inputs.checkbox(new Map([["red", "#f00"], ["green", "#0f0"], ["blue", "#00f"]]));
 }
 
 export async function checkboxMapFormat() {
-  return Checkbox(new Map([["red", "#f00"], ["green", "#0f0"], ["blue", "#00f"]]), {format: ([key, value]) => `${key} (${value})`});
+  return Inputs.checkbox(new Map([["red", "#f00"], ["green", "#0f0"], ["blue", "#00f"]]), {format: ([key, value]) => `${key} (${value})`});
 }
 
 export async function checkboxMapKey() {
-  return Checkbox(new Map([["red", "#f00"], ["green", "#0f0"], ["blue", "#00f"]]), {key: "green"});
+  return Inputs.checkbox(new Map([["red", "#f00"], ["green", "#0f0"], ["blue", "#00f"]]), {key: "green"});
 }
 
 export async function checkboxMapValue() {
-  return Checkbox(new Map([["red", "#f00"], ["green", "#0f0"], ["blue", "#00f"]]), {value: "#0f0"});
+  return Inputs.checkbox(new Map([["red", "#f00"], ["green", "#0f0"], ["blue", "#00f"]]), {value: "#0f0"});
 }
 
 export async function checkboxUnique() {
-  return Checkbox(["red", "red", "green", "Green", "blue", "blue"], {unique: true});
+  return Inputs.checkbox(["red", "red", "green", "Green", "blue", "blue"], {unique: true});
 }
 
 export async function checkboxUniqueFormat() {
-  return Checkbox(["red", "Red", "green", "Green", "blue", "Blue"], {format: x => x.toLowerCase(), unique: true});
+  return Inputs.checkbox(["red", "Red", "green", "Green", "blue", "Blue"], {format: x => x.toLowerCase(), unique: true});
 }
 
 export async function checkboxSortTrue() {
-  return Checkbox([..."CXQZALORBNHTMJDVFGWSKEUPYI"], {sort: true});
+  return Inputs.checkbox([..."CXQZALORBNHTMJDVFGWSKEUPYI"], {sort: true});
 }
 
 export async function checkboxSortFalse() {
-  return Checkbox([..."CXQZALORBNHTMJDVFGWSKEUPYI"], {sort: false});
+  return Inputs.checkbox([..."CXQZALORBNHTMJDVFGWSKEUPYI"], {sort: false});
 }
 
 export async function checkboxSortAscending() {
-  return Checkbox([..."CXQZALORBNHTMJDVFGWSKEUPYI"], {sort: "ascending"});
+  return Inputs.checkbox([..."CXQZALORBNHTMJDVFGWSKEUPYI"], {sort: "ascending"});
 }
 
 export async function checkboxSortDescending() {
-  return Checkbox([..."CXQZALORBNHTMJDVFGWSKEUPYI"], {sort: "descending"});
+  return Inputs.checkbox([..."CXQZALORBNHTMJDVFGWSKEUPYI"], {sort: "descending"});
 }
 
 export async function checkboxSortFunction() {
-  return Checkbox([..."CXQZALORBNHTMJDVFGWSKEUPYI"], {sort: (a, b) => a < b ? -1 : a > b ? 1 : 0});
+  return Inputs.checkbox([..."CXQZALORBNHTMJDVFGWSKEUPYI"], {sort: (a, b) => a < b ? -1 : a > b ? 1 : 0});
 }
 
 export async function checkboxSortFormat() {
-  return Checkbox([..."CXQZaLORbNHtmjDVFGWsKeupyI"], {format: x => x.toLowerCase(), sort: true});
+  return Inputs.checkbox([..."CXQZaLORbNHtmjDVFGWsKeupyI"], {format: x => x.toLowerCase(), sort: true});
 }
 
 export async function checkboxValue() {
-  return Checkbox(["red", "green", "blue"], {value: "green"});
+  return Inputs.checkbox(["red", "green", "blue"], {value: "green"});
 }
 
 export async function checkboxDisabled() {
-  return Checkbox(["red", "green", "blue"], {disabled: true});
+  return Inputs.checkbox(["red", "green", "blue"], {disabled: true});
 }
 
 export async function checkboxDisabledSome() {
-  return Checkbox(["red", "green", "blue"], {disabled: ["green"]});
+  return Inputs.checkbox(["red", "green", "blue"], {disabled: ["green"]});
 }

--- a/test/inputs/radios.js
+++ b/test/inputs/radios.js
@@ -1,78 +1,78 @@
-import {Radio} from "@observablehq/inputs";
+import * as Inputs from "@observablehq/inputs";
 import {html} from "htl";
 
 export async function radio() {
-  return Radio(["red", "green", "blue"]);
+  return Inputs.radio(["red", "green", "blue"]);
 }
 
 export async function radioFormat() {
-  return Radio(["red", "green", "blue"], {format: x => x.toUpperCase()});
+  return Inputs.radio(["red", "green", "blue"], {format: x => x.toUpperCase()});
 }
 
 export async function radioLabel() {
-  return Radio(["red", "green", "blue"], {label: "dollars&pounds"});
+  return Inputs.radio(["red", "green", "blue"], {label: "dollars&pounds"});
 }
 
 export async function radioLabelHtml() {
-  return Radio(["red", "green", "blue"], {label: html`<b>color</b>`});
+  return Inputs.radio(["red", "green", "blue"], {label: html`<b>color</b>`});
 }
 
 export async function radioMap() {
-  return Radio(new Map([["red", "#f00"], ["green", "#0f0"], ["blue", "#00f"]]));
+  return Inputs.radio(new Map([["red", "#f00"], ["green", "#0f0"], ["blue", "#00f"]]));
 }
 
 export async function radioMapFormat() {
-  return Radio(new Map([["red", "#f00"], ["green", "#0f0"], ["blue", "#00f"]]), {format: ([key, value]) => `${key} (${value})`});
+  return Inputs.radio(new Map([["red", "#f00"], ["green", "#0f0"], ["blue", "#00f"]]), {format: ([key, value]) => `${key} (${value})`});
 }
 
 export async function radioMapKey() {
-  return Radio(new Map([["red", "#f00"], ["green", "#0f0"], ["blue", "#00f"]]), {key: "green"});
+  return Inputs.radio(new Map([["red", "#f00"], ["green", "#0f0"], ["blue", "#00f"]]), {key: "green"});
 }
 
 export async function radioMapValue() {
-  return Radio(new Map([["red", "#f00"], ["green", "#0f0"], ["blue", "#00f"]]), {value: "#0f0"});
+  return Inputs.radio(new Map([["red", "#f00"], ["green", "#0f0"], ["blue", "#00f"]]), {value: "#0f0"});
 }
 
 export async function radioUnique() {
-  return Radio(["red", "red", "green", "Green", "blue", "blue"], {unique: true});
+  return Inputs.radio(["red", "red", "green", "Green", "blue", "blue"], {unique: true});
 }
 
 export async function radioUniqueFormat() {
-  return Radio(["red", "Red", "green", "Green", "blue", "Blue"], {format: x => x.toLowerCase(), unique: true});
+  return Inputs.radio(["red", "Red", "green", "Green", "blue", "Blue"], {format: x => x.toLowerCase(), unique: true});
 }
 
 export async function radioSortTrue() {
-  return Radio([..."CXQZALORBNHTMJDVFGWSKEUPYI"], {sort: true});
+  return Inputs.radio([..."CXQZALORBNHTMJDVFGWSKEUPYI"], {sort: true});
 }
 
 export async function radioSortFalse() {
-  return Radio([..."CXQZALORBNHTMJDVFGWSKEUPYI"], {sort: false});
+  return Inputs.radio([..."CXQZALORBNHTMJDVFGWSKEUPYI"], {sort: false});
 }
 
 export async function radioSortAscending() {
-  return Radio([..."CXQZALORBNHTMJDVFGWSKEUPYI"], {sort: "ascending"});
+  return Inputs.radio([..."CXQZALORBNHTMJDVFGWSKEUPYI"], {sort: "ascending"});
 }
 
 export async function radioSortDescending() {
-  return Radio([..."CXQZALORBNHTMJDVFGWSKEUPYI"], {sort: "descending"});
+  return Inputs.radio([..."CXQZALORBNHTMJDVFGWSKEUPYI"], {sort: "descending"});
 }
 
 export async function radioSortFunction() {
-  return Radio([..."CXQZALORBNHTMJDVFGWSKEUPYI"], {sort: (a, b) => a < b ? -1 : a > b ? 1 : 0});
+  return Inputs.radio([..."CXQZALORBNHTMJDVFGWSKEUPYI"], {sort: (a, b) => a < b ? -1 : a > b ? 1 : 0});
 }
 
 export async function radioSortFormat() {
-  return Radio([..."CXQZaLORbNHtmjDVFGWsKeupyI"], {format: x => x.toLowerCase(), sort: true});
+  return Inputs.radio([..."CXQZaLORbNHtmjDVFGWsKeupyI"], {format: x => x.toLowerCase(), sort: true});
 }
 
 export async function radioValue() {
-  return Radio(["red", "green", "blue"], {value: "green"});
+  return Inputs.radio(["red", "green", "blue"], {value: "green"});
 }
 
 export async function radioDisabled() {
-  return Radio(["red", "green", "blue"], {disabled: true});
+  return Inputs.radio(["red", "green", "blue"], {disabled: true});
 }
 
 export async function radioDisabledSome() {
-  return Radio(["red", "green", "blue"], {disabled: ["green"]});
+  return Inputs.radio(["red", "green", "blue"], {disabled: ["green"]});
 }

--- a/test/inputs/ranges.js
+++ b/test/inputs/ranges.js
@@ -1,30 +1,30 @@
-import {Range} from "@observablehq/inputs";
+import * as Inputs from "@observablehq/inputs";
 import {html} from "htl";
 
 export async function range() {
-  return Range();
+  return Inputs.range();
 }
 
 export async function range100() {
-  return Range([0, 100], {step: 1, value: 20});
+  return Inputs.range([0, 100], {step: 1, value: 20});
 }
 
 export async function rangeFixed() {
-  return Range([0, 1], {value: 0.12345, format: x => x.toFixed(3)});
+  return Inputs.range([0, 1], {value: 0.12345, format: x => x.toFixed(3)});
 }
 
 export async function rangeLabel() {
-  return Range([0, 1], {label: "dollars&pounds"});
+  return Inputs.range([0, 1], {label: "dollars&pounds"});
 }
 
 export async function rangeLabelHtml() {
-  return Range([0, 1], {label: html`<b>intensity</b>`});
+  return Inputs.range([0, 1], {label: html`<b>intensity</b>`});
 }
 
 export async function rangeWide() {
-  return Range([0, 1], {width: "20em"});
+  return Inputs.range([0, 1], {width: "20em"});
 }
 
 export async function rangePlaceholder() {
-  return Range([0, 1], {placeholder: "number"});
+  return Inputs.range([0, 1], {placeholder: "number"});
 }

--- a/test/inputs/searches.js
+++ b/test/inputs/searches.js
@@ -1,46 +1,46 @@
-import {Search} from "@observablehq/inputs";
+import * as Inputs from "@observablehq/inputs";
 import {html} from "htl";
 
 export async function search() {
-  return Search(["red", "green", "blue"]);
+  return Inputs.search(["red", "green", "blue"]);
 }
 
 export async function searchLabel() {
-  return Search(["red", "green", "blue"], {label: "dollars&pounds"});
+  return Inputs.search(["red", "green", "blue"], {label: "dollars&pounds"});
 }
 
 export async function searchLabelHtml() {
-  return Search(["red", "green", "blue"], {label: html`<b>color</b>`});
+  return Inputs.search(["red", "green", "blue"], {label: html`<b>color</b>`});
 }
 
 export async function searchLabelQuery() {
-  return Search(["red", "green", "blue", "black"], {label: "colors", query: "bl"});
+  return Inputs.search(["red", "green", "blue", "black"], {label: "colors", query: "bl"});
 }
 
 export async function searchPlaceholder() {
-  return Search(["red", "green", "blue"], {placeholder: "dollars&pounds"});
+  return Inputs.search(["red", "green", "blue"], {placeholder: "dollars&pounds"});
 }
 
 export async function searchFormat() {
-  return Search(["red", "green", "blue", "black"], {query: "b", format: x => `${x > 1 ? ">1" : x} results`});
+  return Inputs.search(["red", "green", "blue", "black"], {query: "b", format: x => `${x > 1 ? ">1" : x} results`});
 }
 
 export async function searchSpellcheck() {
-  return Search(["red", "green", "blue"], {spellcheck: false});
+  return Inputs.search(["red", "green", "blue"], {spellcheck: false});
 }
 
 export async function searchQuery() {
-  return Search(["red", "green", "blue", "black"], {query: "bl"});
+  return Inputs.search(["red", "green", "blue", "black"], {query: "bl"});
 }
 
 export async function searchWide() {
-  return Search(["red", "green", "blue"], {width: "20em"});
+  return Inputs.search(["red", "green", "blue"], {width: "20em"});
 }
 
 export async function searchDatalist() {
-  return Search(["red", "green", "blue"], {datalist: ["red", "green", "blue"]});
+  return Inputs.search(["red", "green", "blue"], {datalist: ["red", "green", "blue"]});
 }
 
 export async function searchDisabled() {
-  return Search(["red", "green", "blue"], {disabled: true});
+  return Inputs.search(["red", "green", "blue"], {disabled: true});
 }

--- a/test/inputs/selects.js
+++ b/test/inputs/selects.js
@@ -1,110 +1,110 @@
-import {Select} from "@observablehq/inputs";
+import * as Inputs from "@observablehq/inputs";
 import {html} from "htl";
 
 export async function select() {
-  return Select(["red", "green", "blue"]);
+  return Inputs.select(["red", "green", "blue"]);
 }
 
 export async function selectFormat() {
-  return Select(["red", "green", "blue"], {format: x => x.toUpperCase()});
+  return Inputs.select(["red", "green", "blue"], {format: x => x.toUpperCase()});
 }
 
 export async function selectLabel() {
-  return Select(["red", "green", "blue"], {label: "dollars&pounds"});
+  return Inputs.select(["red", "green", "blue"], {label: "dollars&pounds"});
 }
 
 export async function selectLabelHtml() {
-  return Select(["red", "green", "blue"], {label: html`<b>color</b>`});
+  return Inputs.select(["red", "green", "blue"], {label: html`<b>color</b>`});
 }
 
 export async function selectMap() {
-  return Select(new Map([["red", "#f00"], ["green", "#0f0"], ["blue", "#00f"]]));
+  return Inputs.select(new Map([["red", "#f00"], ["green", "#0f0"], ["blue", "#00f"]]));
 }
 
 export async function selectMapFormat() {
-  return Select(new Map([["red", "#f00"], ["green", "#0f0"], ["blue", "#00f"]]), {format: ([key, value]) => `${key} (${value})`});
+  return Inputs.select(new Map([["red", "#f00"], ["green", "#0f0"], ["blue", "#00f"]]), {format: ([key, value]) => `${key} (${value})`});
 }
 
 export async function selectMapKey() {
-  return Select(new Map([["red", "#f00"], ["green", "#0f0"], ["blue", "#00f"]]), {key: "green"});
+  return Inputs.select(new Map([["red", "#f00"], ["green", "#0f0"], ["blue", "#00f"]]), {key: "green"});
 }
 
 export async function selectMapValue() {
-  return Select(new Map([["red", "#f00"], ["green", "#0f0"], ["blue", "#00f"]]), {value: "#0f0"});
+  return Inputs.select(new Map([["red", "#f00"], ["green", "#0f0"], ["blue", "#00f"]]), {value: "#0f0"});
 }
 
 export async function selectMultiple() {
-  return Select(["red", "green", "blue"], {label: "colors", multiple: true});
+  return Inputs.select(["red", "green", "blue"], {label: "colors", multiple: true});
 }
 
 export async function selectMultipleValue() {
-  return Select(["red", "green", "blue"], {label: "colors", multiple: true, value: ["red", "blue"]});
+  return Inputs.select(["red", "green", "blue"], {label: "colors", multiple: true, value: ["red", "blue"]});
 }
 
 export async function selectMultipleMapKey() {
-  return Select(new Map([["red", "#f00"], ["green", "#0f0"], ["blue", "#00f"]]), {multiple: true, key: ["red", "blue"]});
+  return Inputs.select(new Map([["red", "#f00"], ["green", "#0f0"], ["blue", "#00f"]]), {multiple: true, key: ["red", "blue"]});
 }
 
 export async function selectMultipleMapValue() {
-  return Select(new Map([["red", "#f00"], ["green", "#0f0"], ["blue", "#00f"]]), {multiple: true, value: ["#f00", "#00f"]});
+  return Inputs.select(new Map([["red", "#f00"], ["green", "#0f0"], ["blue", "#00f"]]), {multiple: true, value: ["#f00", "#00f"]});
 }
 
 export async function selectMultipleLong() {
-  return Select("ABCDEFGHIJKLMNOPQRSTUVWXYZ", {multiple: true});
+  return Inputs.select("ABCDEFGHIJKLMNOPQRSTUVWXYZ", {multiple: true});
 }
 
 export async function selectMultipleSize() {
-  return Select(["red", "green", "blue"], {label: "colors", multiple: 5});
+  return Inputs.select(["red", "green", "blue"], {label: "colors", multiple: 5});
 }
 
 export async function selectUnique() {
-  return Select(["red", "red", "green", "Green", "blue", "blue"], {unique: true});
+  return Inputs.select(["red", "red", "green", "Green", "blue", "blue"], {unique: true});
 }
 
 export async function selectUniqueFormat() {
-  return Select(["red", "Red", "green", "Green", "blue", "Blue"], {format: x => x.toLowerCase(), unique: true});
+  return Inputs.select(["red", "Red", "green", "Green", "blue", "Blue"], {format: x => x.toLowerCase(), unique: true});
 }
 
 export async function selectUniqueMultiple() {
-  return Select(["red", "red", "green", "Green", "blue", "blue"], {unique: true, multiple: true});
+  return Inputs.select(["red", "red", "green", "Green", "blue", "blue"], {unique: true, multiple: true});
 }
 
 export async function selectSortTrue() {
-  return Select([..."CXQZALORBNHTMJDVFGWSKEUPYI"], {sort: true});
+  return Inputs.select([..."CXQZALORBNHTMJDVFGWSKEUPYI"], {sort: true});
 }
 
 export async function selectSortFalse() {
-  return Select([..."CXQZALORBNHTMJDVFGWSKEUPYI"], {sort: false});
+  return Inputs.select([..."CXQZALORBNHTMJDVFGWSKEUPYI"], {sort: false});
 }
 
 export async function selectSortAscending() {
-  return Select([..."CXQZALORBNHTMJDVFGWSKEUPYI"], {sort: "ascending"});
+  return Inputs.select([..."CXQZALORBNHTMJDVFGWSKEUPYI"], {sort: "ascending"});
 }
 
 export async function selectSortDescending() {
-  return Select([..."CXQZALORBNHTMJDVFGWSKEUPYI"], {sort: "descending"});
+  return Inputs.select([..."CXQZALORBNHTMJDVFGWSKEUPYI"], {sort: "descending"});
 }
 
 export async function selectSortFunction() {
-  return Select([..."CXQZALORBNHTMJDVFGWSKEUPYI"], {sort: (a, b) => a < b ? -1 : a > b ? 1 : 0});
+  return Inputs.select([..."CXQZALORBNHTMJDVFGWSKEUPYI"], {sort: (a, b) => a < b ? -1 : a > b ? 1 : 0});
 }
 
 export async function selectSortFormat() {
-  return Select([..."CXQZaLORbNHtmjDVFGWsKeupyI"], {format: x => x.toLowerCase(), sort: true});
+  return Inputs.select([..."CXQZaLORbNHtmjDVFGWsKeupyI"], {format: x => x.toLowerCase(), sort: true});
 }
 
 export async function selectValue() {
-  return Select(["red", "green", "blue"], {value: "green"});
+  return Inputs.select(["red", "green", "blue"], {value: "green"});
 }
 
 export async function selectWide() {
-  return Select(["red", "green", "blue"], {width: "20em"});
+  return Inputs.select(["red", "green", "blue"], {width: "20em"});
 }
 
 export async function selectDisabled() {
-  return Select(["red", "green", "blue"], {disabled: true});
+  return Inputs.select(["red", "green", "blue"], {disabled: true});
 }
 
 export async function selectDisabledSome() {
-  return Select(["red", "green", "blue"], {disabled: ["green"]});
+  return Inputs.select(["red", "green", "blue"], {disabled: ["green"]});
 }

--- a/test/inputs/tables.js
+++ b/test/inputs/tables.js
@@ -1,7 +1,7 @@
-import {Table} from "@observablehq/inputs";
+import * as Inputs from "@observablehq/inputs";
 import * as d3 from "d3";
 
 export async function table() {
   const athletes = await d3.csv("data/athletes.csv");
-  return Table(athletes);
+  return Inputs.table(athletes);
 }

--- a/test/inputs/textareas.js
+++ b/test/inputs/textareas.js
@@ -1,78 +1,78 @@
-import {Textarea} from "@observablehq/inputs";
+import * as Inputs from "@observablehq/inputs";
 import {html} from "htl";
 
 export async function textarea() {
-  return Textarea();
+  return Inputs.textarea();
 }
 
 export async function textareaLabel() {
-  return Textarea({label: "dollars&pounds"});
+  return Inputs.textarea({label: "dollars&pounds"});
 }
 
 export async function textareaLabelHtml() {
-  return Textarea({label: html`<b>intensity</b>`});
+  return Inputs.textarea({label: html`<b>intensity</b>`});
 }
 
 export async function textareaValue() {
-  return Textarea({value: "hello world"});
+  return Inputs.textarea({value: "hello world"});
 }
 
 export async function textareaValueDanger() {
-  return Textarea({value: "hello world </textarea>"});
+  return Inputs.textarea({value: "hello world </textarea>"});
 }
 
 export async function textareaPlaceholder() {
-  return Textarea({placeholder: "hello world"});
+  return Inputs.textarea({placeholder: "hello world"});
 }
 
 export async function textareaSpellcheckFalse() {
-  return Textarea({spellcheck: false});
+  return Inputs.textarea({spellcheck: false});
 }
 
 export async function textareaSubmit() {
-  return Textarea({submit: true});
+  return Inputs.textarea({submit: true});
 }
 
 export async function textareaSubmitCustom() {
-  return Textarea({submit: "dollars&pounds"});
+  return Inputs.textarea({submit: "dollars&pounds"});
 }
 
 export async function textareaSubmitHtml() {
-  return Textarea({submit: html`<b>Update</b>`});
+  return Inputs.textarea({submit: html`<b>Update</b>`});
 }
 
 export async function textareaWide() {
-  return Textarea({width: "20em"});
+  return Inputs.textarea({width: "20em"});
 }
 
 export async function textareaCols() {
-  return Textarea({cols: 80});
+  return Inputs.textarea({cols: 80});
 }
 
 export async function textareaColsWidth() {
-  return Textarea({cols: 80, width: 500});
+  return Inputs.textarea({cols: 80, width: 500});
 }
 
 export async function textareaRows() {
-  return Textarea({rows: 20});
+  return Inputs.textarea({rows: 20});
 }
 
 export async function textareaMinlength() {
-  return Textarea({minlength: 10});
+  return Inputs.textarea({minlength: 10});
 }
 
 export async function textareaMaxlength() {
-  return Textarea({maxlength: 10});
+  return Inputs.textarea({maxlength: 10});
 }
 
 export async function textareaResize() {
-  return Textarea({resize: false});
+  return Inputs.textarea({resize: false});
 }
 
 export async function textareaDisabled() {
-  return Textarea({disabled: true});
+  return Inputs.textarea({disabled: true});
 }
 
 export async function textareaReadonly() {
-  return Textarea({readonly: true});
+  return Inputs.textarea({readonly: true});
 }

--- a/test/inputs/texts.js
+++ b/test/inputs/texts.js
@@ -1,66 +1,66 @@
-import {Text} from "@observablehq/inputs";
+import * as Inputs from "@observablehq/inputs";
 import {html} from "htl";
 
 export async function text() {
-  return Text();
+  return Inputs.text();
 }
 
 export async function textLabel() {
-  return Text({label: "dollars&pounds"});
+  return Inputs.text({label: "dollars&pounds"});
 }
 
 export async function textLabelHtml() {
-  return Text({label: html`<b>intensity</b>`});
+  return Inputs.text({label: html`<b>intensity</b>`});
 }
 
 export async function textValue() {
-  return Text({value: "hello world"});
+  return Inputs.text({value: "hello world"});
 }
 
 export async function textPlaceholder() {
-  return Text({placeholder: "hello world"});
+  return Inputs.text({placeholder: "hello world"});
 }
 
 export async function textSpellcheckFalse() {
-  return Text({spellcheck: false});
+  return Inputs.text({spellcheck: false});
 }
 
 export async function textSubmit() {
-  return Text({submit: true});
+  return Inputs.text({submit: true});
 }
 
 export async function textSubmitCustom() {
-  return Text({submit: "dollars&pounds"});
+  return Inputs.text({submit: "dollars&pounds"});
 }
 
 export async function textSubmitHtml() {
-  return Text({submit: html`<b>Update</b>`});
+  return Inputs.text({submit: html`<b>Update</b>`});
 }
 
 export async function textWide() {
-  return Text({width: "20em"});
+  return Inputs.text({width: "20em"});
 }
 
 export async function textMinlength() {
-  return Text({minlength: 10});
+  return Inputs.text({minlength: 10});
 }
 
 export async function textMaxlength() {
-  return Text({maxlength: 10});
+  return Inputs.text({maxlength: 10});
 }
 
 export async function textDatalist() {
-  return Text({datalist: ["red", "green", "blue"]});
+  return Inputs.text({datalist: ["red", "green", "blue"]});
 }
 
 export async function textDisabled() {
-  return Text({disabled: true});
+  return Inputs.text({disabled: true});
 }
 
 export async function textReadonly() {
-  return Text({readonly: true});
+  return Inputs.text({readonly: true});
 }
 
 export async function textPassword() {
-  return Text({type: "password"});
+  return Inputs.text({type: "password"});
 }

--- a/test/radio-test.js
+++ b/test/radio-test.js
@@ -1,15 +1,15 @@
-import {Radio} from "@observablehq/inputs";
+import * as Inputs from "@observablehq/inputs";
 import tape from "./jsdom.js";
 
-tape("Radio([]) handles empty options", test => {
-  const r = Radio([]);
+tape("Inputs.radio([]) handles empty options", test => {
+  const r = Inputs.radio([]);
   test.equal(r.value, null);
   r.value = "red";
   test.equal(r.value, null);
 });
 
-tape("Radio([value]) handles singular option", test => {
-  const r = Radio(["red"]);
+tape("Inputs.radio([value]) handles singular option", test => {
+  const r = Inputs.radio(["red"]);
   test.equal(r.value, null);
   r.value = "blue";
   test.equal(r.value, null);
@@ -19,10 +19,10 @@ tape("Radio([value]) handles singular option", test => {
   test.equal(r.value, "red");
 });
 
-// JSDOM doesn’t support RadioNodeList…
+// JSDOM doesn’t support Inputs.radioNodeList…
 // https://github.com/jsdom/jsdom/issues/2600
-tape.skip("Radio(values) supports value getter and setter", test => {
-  const r = Radio(["red", "blue"]);
+tape.skip("Inputs.radio(values) supports value getter and setter", test => {
+  const r = Inputs.radio(["red", "blue"]);
   test.equal(r.value, null);
   r.value = "blue";
   test.equal(r.value, "blue");

--- a/test/range-test.js
+++ b/test/range-test.js
@@ -1,61 +1,61 @@
-import {Range} from "@observablehq/inputs";
+import * as Inputs from "@observablehq/inputs";
 import {html} from "htl";
 import {number, string} from "./coercible.js";
 import tape from "./jsdom.js";
 
-tape("Range([min, max]) sets the min and max", test => {
-  const r = Range([0, 100]);
+tape("Inputs.range([min, max]) sets the min and max", test => {
+  const r = Inputs.range([0, 100]);
   test.equal(r.elements.range.min, "0");
   test.equal(r.elements.range.max, "100");
-  const s = Range([number(0), number(100)]);
+  const s = Inputs.range([number(0), number(100)]);
   test.equal(s.elements.range.min, "0");
   test.equal(s.elements.range.max, "100");
 });
 
 // JSDOM does not implement inputs correctly…
-tape.skip("Range([min, max]) sets the initial value to (min + max) / 2", test => {
-  test.equal(Range([0, 1]).value, 0.5);
-  test.equal(Range([20, 40]).value, 30);
+tape.skip("Inputs.range([min, max]) sets the initial value to (min + max) / 2", test => {
+  test.equal(Inputs.range([0, 1]).value, 0.5);
+  test.equal(Inputs.range([20, 40]).value, 30);
 });
 
-tape("Range() is equivalent to Range([0, 1])", test => {
-  const r = Range();
+tape("Inputs.range() is equivalent to Inputs.range([0, 1])", test => {
+  const r = Inputs.range();
   // test.equal(r.value, 0.5); // JSDOM
   test.equal(r.elements.range.min, "0");
   test.equal(r.elements.range.max, "1");
   test.equal(r.elements.range.step, "any");
 });
 
-tape("Range(…, {label}) sets the label", test => {
-  test.equal(Range([0, 1], {label: "foo"}).textContent.trim(), "foo");
-  test.equal(Range([0, 100], {label: "bar"}).textContent.trim(), "bar");
-  test.equal(Range([0, 100], {label: html`<b>bar</b>`}).textContent.trim(), "bar");
+tape("Inputs.range(…, {label}) sets the label", test => {
+  test.equal(Inputs.range([0, 1], {label: "foo"}).textContent.trim(), "foo");
+  test.equal(Inputs.range([0, 100], {label: "bar"}).textContent.trim(), "bar");
+  test.equal(Inputs.range([0, 100], {label: html`<b>bar</b>`}).textContent.trim(), "bar");
 });
 
-tape("Range(…, {format}) sets the format", test => {
-  // test.equal(Range([0, 1], {format: d => d.toFixed(4)}).elements.number.value, "0.5000"); // JSDOM
-  test.throws(() => Range([0, 1], {format: "foo"}), TypeError);
+tape("Inputs.range(…, {format}) sets the format", test => {
+  // test.equal(Inputs.range([0, 1], {format: d => d.toFixed(4)}).elements.number.value, "0.5000"); // JSDOM
+  test.throws(() => Inputs.range([0, 1], {format: "foo"}), TypeError);
 });
 
-tape("Range(…, {step}) sets the step", test => {
-  test.equal(Range([0, 100], {step: 10}).elements.range.step, "10");
-  test.equal(Range([0, 100], {step: undefined}).elements.range.step, "any");
-  test.equal(Range([0, 100], {step: number(10)}).elements.range.step, "10");
+tape("Inputs.range(…, {step}) sets the step", test => {
+  test.equal(Inputs.range([0, 100], {step: 10}).elements.range.step, "10");
+  test.equal(Inputs.range([0, 100], {step: undefined}).elements.range.step, "any");
+  test.equal(Inputs.range([0, 100], {step: number(10)}).elements.range.step, "10");
 });
 
 // JSDOM does not implement inputs correctly…
-tape.skip("Range(…, {step}) affects the initial value", test => {
-  const r = Range([0, 100], {step: 7}); // 50 is not a multiple of 7
+tape.skip("Inputs.range(…, {step}) affects the initial value", test => {
+  const r = Inputs.range([0, 100], {step: 7}); // 50 is not a multiple of 7
   test.equal(r.elements.range.value, "49");
   test.equal(r.value, 49);
 });
 
-tape("Range(…, {value}) sets the initial value", test => {
-  const r = Range([0, 100], {value: 10});
+tape("Inputs.range(…, {value}) sets the initial value", test => {
+  const r = Inputs.range([0, 100], {value: 10});
   test.equal(r.value, 10);
   test.equal(r.elements.range.valueAsNumber, 10);
   test.equal(r.elements.number.value, "10");
-  const s = Range([0, 100], {value: string("10")});
+  const s = Inputs.range([0, 100], {value: string("10")});
   test.equal(s.value, 10);
   test.equal(s.elements.range.valueAsNumber, 10);
   test.equal(s.elements.number.value, "10");

--- a/test/scratch.html
+++ b/test/scratch.html
@@ -214,9 +214,9 @@ form {
 <body class="observablehq">
   <script type="module">
 
-import {Range} from "@observablehq/inputs";
+import * as Inputs from "@observablehq/inputs";
 
-document.body.appendChild(Range());
+document.body.appendChild(Inputs.range());
 
   </script>
 </body>

--- a/test/select-test.js
+++ b/test/select-test.js
@@ -1,25 +1,25 @@
-import {Select} from "@observablehq/inputs";
+import * as Inputs from "@observablehq/inputs";
 import {string} from "./coercible.js";
 import tape from "./jsdom.js";
 
-tape("Select(options) sets the options", test => {
-  const s = Select(["red", "green", "blue"]);
+tape("Inputs.select(options) sets the options", test => {
+  const s = Inputs.select(["red", "green", "blue"]);
   test.deepEqual(Array.from(s.elements.input.options, o => o.textContent), ["red", "green", "blue"]);
   test.equal(s.value, "red");
   const red = string("red"), green = string("green"), blue = string("blue");
-  const c = Select([red, green, blue]);
+  const c = Inputs.select([red, green, blue]);
   test.deepEqual(Array.from(c.elements.input.options, o => o.textContent), ["red", "green", "blue"]);
   test.equal(c.value, red);
 });
 
-tape("Select(options) formats null as empty by default", test => {
-  const s = Select(["red", null, "blue"], {value: null});
+tape("Inputs.select(options) formats null as empty by default", test => {
+  const s = Inputs.select(["red", null, "blue"], {value: null});
   test.deepEqual(Array.from(s.elements.input.options, o => o.textContent), ["red", "", "blue"]);
   test.equal(s.value, null);
 });
 
-tape("Select(…, {format}) sets the format function", test => {
-  const s = Select(["red", null, "blue"], {format: x => x && x.toUpperCase()});
+tape("Inputs.select(…, {format}) sets the format function", test => {
+  const s = Inputs.select(["red", null, "blue"], {format: x => x && x.toUpperCase()});
   test.deepEqual(Array.from(s.elements.input.options, o => o.textContent), ["RED", "", "BLUE"]);
   test.equal(s.value, "red");
 });

--- a/test/toggle-test.js
+++ b/test/toggle-test.js
@@ -1,8 +1,8 @@
-import {Toggle} from "@observablehq/inputs";
+import * as Inputs from "@observablehq/inputs";
 import tape from "./jsdom.js";
 
-tape("Toggle({values}) handles custom values", test => {
-  const t = Toggle({values: [1, 0]});
+tape("Inputs.toggle({values}) handles custom values", test => {
+  const t = Inputs.toggle({values: [1, 0]});
   test.equal(t.value, 0);
   test.equal(t.elements.input.checked, false);
   t.value = 1;


### PR DESCRIPTION
This downcases all Inputs for symmetry with Observable Plot (*e.g.*, Inputs.table and Plot.barY). This will be a “major” version change to 0.8, and I will keep the symbols as uppercase in the Observable Inputs notebook for backwards compatibility. Once this is published, I will update https://github.com/observablehq/stdlib/pull/207.