### PR TITLE
Wider range, with ellipsis

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -157,6 +157,8 @@ form.__ns__-toggle .__ns__-input {
 /* Use tabular-nums to avoid jitter when moving the range slider. */
 .__ns__-input > input[type=number] {
   font-variant-numeric: tabular-nums;
+  flex-shrink: 1.5;
+  text-overflow: ellipsis;
 }
 
 /* Separate the range input from the preceding number input. */


### PR DESCRIPTION
Fixes #113.

The default wider appearance reduces the likelihood of truncation with large values:

<img width="382" alt="Screen Shot 2021-05-12 at 8 11 45 AM" src="https://user-images.githubusercontent.com/230541/117999520-c8c6ba80-b2f9-11eb-8c47-b3a7346a1f06.png">

And when the value is truncated, an ellipsis is shown:

<img width="380" alt="Screen Shot 2021-05-12 at 8 11 56 AM" src="https://user-images.githubusercontent.com/230541/117999513-c82e2400-b2f9-11eb-8ac7-6a53cfde63a7.png">

The ellipsis is arguably undesirable if the truncated digits are past the decimal point, but I think it’s better to always have the ellipsis than to try to do anything smarter.

<img width="379" alt="Screen Shot 2021-05-12 at 8 13 49 AM" src="https://user-images.githubusercontent.com/230541/117999792-104d4680-b2fa-11eb-8bc6-57f9a2490307.png">

The recommended practice is to specify a step so that a huge number of digits isn’t displayed anyway.

<img width="378" alt="Screen Shot 2021-05-12 at 8 14 04 AM" src="https://user-images.githubusercontent.com/230541/117999790-104d4680-b2fa-11eb-932d-865566bf06f5.png">
