### PR TITLE
default to formatLocaleAuto, not stringify

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ A Table displays a tabular dataset; *data* should be an iterable of objects, suc
 
 While intended primarily for display, a Table also serves as an input. The value of the Table is its selected rows: a filtered (and possibly sorted) view of the *data*. Rows can be selected by clicking or shift-clicking checkboxes. See also [Search](#Search), which can be used for rapid filtering of the table’s rows.
 
-By default, the Table infers the type of each column by inspecting values, assuming that non-null values in each column have consistent types. Numbers are formatted in English; dates are formatted in ISO 8601 UTC. Numbers columns are further right-aligned with [tabular figures](https://practicaltypography.com/alternate-figures.html) to assist comparison. The *format* and *align* of each column can be customized as options if desired.
+By default, the Table infers the type of each column by inspecting values, assuming that non-null values in each column have consistent types. Numbers are formatted in the specified *locale*; dates are formatted in ISO 8601 UTC. Numbers columns are further right-aligned with [tabular figures](https://practicaltypography.com/alternate-figures.html) to assist comparison. The *format* and *align* of each column can be customized as options if desired.
 
 By default, the Table uses fixed layout if *data* has fewer than twelve columns. This improves performance and avoids reflow when scrolling due to lazily-rendered rows. If *data* has twelve or more columns, the auto layout is used instead, which automatically sizes columns based on the content. This behavior can be changed by specifying the *layout* option explicitly.
 

--- a/src/checkbox.js
+++ b/src/checkbox.js
@@ -1,5 +1,6 @@
 import {html} from "htl";
 import {createChooser} from "./chooser.js";
+import {stringify} from "./format.js";
 import {maybeLabel} from "./label.js";
 
 function createCheckbox(multiple, type) {
@@ -80,7 +81,7 @@ class OptionOne {
   set value(v) {
     const {_input} = this;
     if (_input.checked) return;
-    _input.checked = (v + "") === _input.value;
+    _input.checked = stringify(v) === _input.value;
   }
   *[Symbol.iterator]() {
     yield this._input;
@@ -98,7 +99,7 @@ class MultipleOptionOne {
   set value(v) {
     const {_input} = this;
     if (_input.checked) return;
-    _input.checked = (v + "") === _input.value;
+    _input.checked = stringify(v) === _input.value;
     this._value = _input.checked ? [_input.value] : [];
   }
   *[Symbol.iterator]() {

--- a/src/format.js
+++ b/src/format.js
@@ -1,3 +1,5 @@
+// Note: use formatAuto (or any other localized format) to present values to the
+// user; stringify is only intended for machine values.
 export function stringify(x) {
   return x == null ? "" : x + "";
 }

--- a/src/search.js
+++ b/src/search.js
@@ -24,7 +24,7 @@ export function search(data, {
   data = arrayify(data);
   required = !!required;
   const [list, listId] = maybeDatalist(datalist);
-  const input = html`<input name=input type=search list=${listId} disabled=${disabled} spellcheck=${spellcheck === undefined ? false : spellcheck + ""} placeholder=${placeholder} value=${query} oninput=${oninput}>`;
+  const input = html`<input name=input type=search list=${listId} disabled=${disabled} spellcheck=${spellcheck === undefined ? false : spellcheck === null ? null : spellcheck + ""} placeholder=${placeholder} value=${query} oninput=${oninput}>`;
   const output = html`<output name=output>`;
   const form = html`<form class=__ns__ onsubmit=${preventDefault} style=${maybeWidth(width)}>
     ${maybeLabel(label, input)}<div class=__ns__-input>

--- a/src/table.js
+++ b/src/table.js
@@ -1,7 +1,7 @@
 import {html} from "htl";
 import {arrayify} from "./array.js";
 import {length} from "./css.js";
-import {formatDate, formatLocaleNumber, stringify} from "./format.js";
+import {formatDate, formatLocaleAuto, formatLocaleNumber} from "./format.js";
 import {newId} from "./id.js";
 import {identity} from "./identity.js";
 import {defined, ascending, descending} from "./sort.js";
@@ -311,7 +311,7 @@ function formatof(base = {}, data, columns, locale) {
     switch (type(data, column)) {
       case "number": format[column] = formatLocaleNumber(locale); break;
       case "date": format[column] = formatDate; break;
-      default: format[column] = stringify; break;
+      default: format[column] = formatLocaleAuto(locale); break;
     }
   }
   return format;

--- a/src/text.js
+++ b/src/text.js
@@ -74,7 +74,7 @@ export function text({
   ...options
 } = {}) {
   const [list, listId] = maybeDatalist(datalist);
-  const input = html`<input type=${type} name=text list=${listId} readonly=${readonly} disabled=${disabled} required=${required} min=${min} max=${max} minlength=${minlength} maxlength=${maxlength} pattern=${pattern} spellcheck=${spellcheck === undefined ? false : spellcheck + ""} placeholder=${placeholder}>`;
+  const input = html`<input type=${type} name=text list=${listId} readonly=${readonly} disabled=${disabled} required=${required} min=${min} max=${max} minlength=${minlength} maxlength=${maxlength} pattern=${pattern} spellcheck=${spellcheck === undefined ? false : spellcheck === null ? null : spellcheck + ""} placeholder=${placeholder}>`;
   const form = html`<form class=__ns__ style=${maybeWidth(width)}>
     ${maybeLabel(label, input)}<div class=__ns__-input>
       ${input}

--- a/src/textarea.js
+++ b/src/textarea.js
@@ -18,7 +18,7 @@ export function textarea({
   width,
   ...options
 } = {}) {
-  const input = html`<textarea name=text readonly=${readonly} disabled=${disabled} required=${required} rows=${rows} minlength=${minlength} maxlength=${maxlength} spellcheck=${spellcheck === undefined ? false : spellcheck + ""} placeholder=${placeholder} onkeydown=${onkeydown} style=${{width, fontFamily: monospace ? "var(--monospace, monospace)" : null, resize: resize ? null : "none"}}>`;
+  const input = html`<textarea name=text readonly=${readonly} disabled=${disabled} required=${required} rows=${rows} minlength=${minlength} maxlength=${maxlength} spellcheck=${spellcheck === undefined ? false : spellcheck === null ? null : spellcheck + ""} placeholder=${placeholder} onkeydown=${onkeydown} style=${{width, fontFamily: monospace ? "var(--monospace, monospace)" : null, resize: resize ? null : "none"}}>`;
   const form = html`<form class="__ns__ __ns__-textarea" style=${maybeWidth(width)}>
     ${maybeLabel(label, input)}<div>
       ${input}

--- a/test/inputs/tables.js
+++ b/test/inputs/tables.js
@@ -15,3 +15,7 @@ export function tableSparse() {
   sparse[8] = {a: 1};
   return Inputs.table(sparse);
 }
+
+export function tableVariousDates() {
+  return Inputs.table([{A: "Hello, not a date"}, {A: new Date(Date.UTC(2000, 0, 1))}]);
+}

--- a/test/output/tableVariousDates.html
+++ b/test/output/tableVariousDates.html
@@ -1,0 +1,21 @@
+<form class="__ns__ __ns__-table" id="__ns__-1" style="max-height: 274px;">
+  <table style="table-layout: fixed;">
+    <thead>
+      <tr>
+        <th><input type="checkbox"></th>
+        <th title="A"><span></span>A</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><input type="checkbox" value="0"></td>
+        <td>Hello, not a date</td>
+      </tr>
+      <tr>
+        <td><input type="checkbox" value="1"></td>
+        <td>2000-01-01</td>
+      </tr>
+    </tbody>
+  </table>
+  <style></style>
+</form>


### PR DESCRIPTION
Supersedes #171.

Rather than try to do it everywhere, this just changes the default format for Inputs.table so that mixed-type columns are still formatted nicely (and consistently).

I found a couple places that should be using stringify, but aren’t. And for the _spellcheck_ option, I assume that we want null to not create the spellcheck attribute, rather than setting it to the literal string “null”.