### PR TITLE
use Inputs as global

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "node": ">=14.5.0"
   },
   "scripts": {
-    "test": "mkdir -p test/output && mocha -r module-alias/register 'test/**/*-test.js' && mocha -r module-alias/register test/input.js && eslint src test",
+    "test": "mkdir -p test/output && mocha -r module-alias/register 'test/**/*-test.js' test/input.js && eslint src test",
     "prepublishOnly": "rm -rf dist && rollup -c",
     "postpublish": "git push && git push --tags",
     "dev": "snowpack dev"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -54,7 +54,7 @@ const config = {
   output: {
     indent: false,
     banner: `// ${meta.name} v${meta.version} Copyright ${copyrights.join(", ")}`,
-    name: "observablehq.Inputs",
+    name: "Inputs",
     format: "umd",
     extend: true,
     globals: {"htl": "htl"},

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -54,7 +54,7 @@ const config = {
   output: {
     indent: false,
     banner: `// ${meta.name} v${meta.version} Copyright ${copyrights.join(", ")}`,
-    name: "observablehq",
+    name: "observablehq.Inputs",
     format: "umd",
     extend: true,
     globals: {"htl": "htl"},


### PR DESCRIPTION
This way, it matches the behavior on Observable, and we don’t have to worry about internal conflicts (with the standard library). Alternatively if we wanted to be safer, we could use `observablehq.Inputs`, but then we’d probably want to change Plot to use `observablehq.Plot`, and I think that’s still likely to trip people up.

Ref. https://talk.observablehq.com/t/how-to-make-the-code-dowloaded-workin-in-a-local-application-without-network/5516/7