### PR TITLE
better support for arrow, arquero columns

### DIFF
--- a/src/array.js
+++ b/src/array.js
@@ -1,3 +1,13 @@
 export function arrayify(array) {
   return Array.isArray(array) ? array : Array.from(array);
 }
+
+function iterable(array) {
+  return array ? typeof array[Symbol.iterator] === "function" : false;
+}
+
+export function maybeColumns(data) {
+  if (iterable(data.columns)) return data.columns; // d3-dsv, FileAttachment
+  if (data.schema && iterable(data.schema.fields)) return Array.from(data.schema.fields, f => f.name); // apache-arrow
+  if (typeof data.columnNames === "function") return data.columnNames(); // arquero
+}

--- a/src/search.js
+++ b/src/search.js
@@ -1,5 +1,5 @@
 import {html} from "htl";
-import {arrayify} from "./array.js";
+import {arrayify, maybeColumns} from "./array.js";
 import {maybeWidth} from "./css.js";
 import {maybeDatalist} from "./datalist.js";
 import {preventDefault} from "./event.js";
@@ -13,7 +13,7 @@ export function search(data, {
   label,
   query = "", // initial search query
   placeholder = "Search", // placeholder text to show when empty
-  columns = data.columns,
+  columns = maybeColumns(data),
   spellcheck,
   autocomplete,
   autocapitalize,

--- a/src/table.js
+++ b/src/table.js
@@ -1,5 +1,5 @@
 import {html} from "htl";
-import {arrayify} from "./array.js";
+import {arrayify, maybeColumns} from "./array.js";
 import {length} from "./css.js";
 import {formatDate, formatLocaleAuto, formatLocaleNumber} from "./format.js";
 import {newId} from "./id.js";
@@ -42,7 +42,7 @@ function initialize(
   },
   data,
   {
-    columns, // array of column names
+    columns = maybeColumns(data), // array of column names
     value, // initial selection
     required = true, // if true, the value is everything if nothing is selected
     sort, // name of column to sort by, if any
@@ -372,9 +372,6 @@ function lengthof(data) {
 }
 
 function columnsof(data) {
-  if (Array.isArray(data.columns)) return data.columns; // d3-dsv, FileAttachment
-  if (data.schema && Array.isArray(data.schema.fields)) return data.schema.fields.map(f => f.name); // apache-arrow
-  if (typeof data.columnNames === "function") return data.columnNames(); // arquero
   const columns = new Set();
   for (const row of data) {
     for (const name in row) {


### PR DESCRIPTION
Inputs.search previously required that _data_.columns, if present, be an array of column names. That led to a false-positive with certain representations including Arquero tables which often expose a _table_.columns function. (This undocumented method is not part of the [Table API](https://uwdata.github.io/arquero/api/table); however, it is part of the [ColumnTable implementation](https://github.com/uwdata/arquero/blob/39cf949efce1ccca5e3a197b430d465b2949f1fb/src/table/column-table.js#L119-L125).)

Now Inputs.search requires that _data_.columns is iterable (_e.g._, an array), not merely defined. In addition, I extended the special-case logic for column detection on Arquero and Arrow tables that was added for Inputs.table in #137 to also apply to Inputs.search.

Fixes #198.