### PR TITLE
Allow string specifiers for date and number formats in tables

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
     "snowpack": "3"
   },
   "dependencies": {
+    "d3-format": "^3.1.0",
+    "d3-time-format": "^4.1.0",
     "htl": "0.3",
     "isoformat": "^0.2.0"
   },

--- a/src/table.js
+++ b/src/table.js
@@ -5,6 +5,8 @@ import {formatDate, formatLocaleAuto, formatLocaleNumber} from "./format.js";
 import {newId} from "./id.js";
 import {identity} from "./identity.js";
 import {defined, ascending, descending} from "./sort.js";
+import {format as d3Format} from "d3-format";
+import {utcFormat as d3UtcFormat} from "d3-time-format";
 
 const rowHeight = 22;
 
@@ -330,7 +332,10 @@ function formatof(base = {}, data, columns, locale) {
   const format = Object.create(null);
   for (const column of columns) {
     if (column in base) {
-      format[column] = base[column];
+      format[column] = typeof(base[column]) === "string" ? 
+        type(data, column) === "date" ? d3UtcFormat(base[column]) :             
+          d3Format(base[column]) : 
+        base[column];
       continue;
     }
     switch (type(data, column)) {


### PR DESCRIPTION
Allow string specifiers for table column formats, for example:

```js
Inputs.table(data, {
  format: {
    price_in_usd: "$",  // currency format
    date: "%B %d, %Y",  // utc format dates
    user_id: ""  
  }, 
  columns: ["price_in_usd", "user_id", "date"]
})
```

See [this notebook](https://observablehq.com/@observablehq/inputs-table-format) as an example. Note, this introduces new dependencies `d3-format` and `d3-time-format`, which I understand may be undesirable. 