### PR TITLE
compose default format with keyof

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The available *options* are:
 * *sort* - true, “ascending”, “descending”, or a comparator function to sort keys; defaults to false.
 * *unique* - true to only show unique keys; defaults to false.
 * *locale* - the current locale; defaults to English.
-* *format* - a format function; defaults to [formatLocaleAuto](#formatLocaleAuto).
+* *format* - a format function; defaults to [formatLocaleAuto](#formatLocaleAuto) composed with *keyof*.
 * *keyof* - a function to return the key for the given element in *data*.
 * *valueof* - a function to return the value of the given element in *data*.
 * *value* - the initial value, an array; defaults to an empty array (no selection).
@@ -157,7 +157,7 @@ The available *options* are:
 * *sort* - true, “ascending”, “descending”, or a comparator function to sort keys; defaults to false.
 * *unique* - true to only show unique keys; defaults to false.
 * *locale* - the current locale; defaults to English.
-* *format* - a format function; defaults to [formatLocaleAuto](#formatLocaleAuto).
+* *format* - a format function; defaults to [formatLocaleAuto](#formatLocaleAuto) composed with *keyof*.
 * *keyof* - a function to return the key for the given element in *data*.
 * *valueof* - a function to return the value of the given element in *data*.
 * *value* - the initial value; defaults to null (no selection).
@@ -274,7 +274,7 @@ The available *options* are:
 * *sort* - true, “ascending”, “descending”, or a comparator function to sort keys; defaults to false.
 * *unique* - true to only show unique keys; defaults to false.
 * *locale* - the current locale; defaults to English.
-* *format* - a format function; defaults to [formatLocaleAuto](#formatLocaleAuto).
+* *format* - a format function; defaults to [formatLocaleAuto](#formatLocaleAuto) composed with *keyof*.
 * *keyof* - a function to return the key for the given element in *data*.
 * *valueof* - a function to return the value of the given element in *data*.
 * *value* - the initial value, an array if multiple choice is allowed.

--- a/src/button.js
+++ b/src/button.js
@@ -22,7 +22,8 @@ export function button(content = "≡", {
     if (!required && value === undefined) value = null;
     disabled = new Set(disabled === true ? Array.from(content, ([content]) => content) : disabled || undefined);
   }
-  const form = html`<form class=__ns__ onsubmit=${preventDefault}>`;
+  const form = html`<form class=__ns__>`;
+  form.addEventListener("submit", preventDefault);
   const style = {width: length(width)};
   const buttons = Array.from(content, ([content, reduce = identity]) => {
     if (typeof reduce !== "function") throw new TypeError("reduce is not a function");

--- a/src/chooser.js
+++ b/src/chooser.js
@@ -12,7 +12,7 @@ export function createChooser({multiple: fixedMultiple, render, selectedIndexes,
     locale,
     keyof = data instanceof Map ? first : identity,
     valueof = data instanceof Map ? second : identity,
-    format = data instanceof Map ? first : formatLocaleAuto(locale),
+    format = (f => (d, i, data) => f(keyof(d, i, data)))(formatLocaleAuto(locale)),
     multiple,
     key,
     value,
@@ -49,11 +49,11 @@ export function createChooser({multiple: fixedMultiple, render, selectedIndexes,
         size
       }
     );
-    form.onchange = dispatchInput;
-    form.oninput = oninput;
-    form.onsubmit = preventDefault;
+    form.addEventListener("input", oninput);
+    form.addEventListener("change", dispatchInput);
+    form.addEventListener("submit", preventDefault);
     function oninput(event) {
-      if (event && event.isTrusted) form.onchange = null;
+      if (event && event.isTrusted) form.removeEventListener("change", dispatchInput);
       if (multiple) {
         value = selectedIndexes(input).map(i => valueof(data[i], i, data));
       } else {

--- a/src/range.js
+++ b/src/range.js
@@ -53,11 +53,12 @@ function createRange({
     range = null;
     transform = invert = identity;
   }
-  const form = html`<form class=__ns__ onsubmit=${preventDefault} style=${maybeWidth(width)}>
+  const form = html`<form class=__ns__ style=${maybeWidth(width)}>
     ${maybeLabel(label, number)}<div class=__ns__-input>
       ${number}${range}
     </div>
   </form>`;
+  form.addEventListener("submit", preventDefault);
   // If range, use an untransformed range to round to the nearest valid value.
   function coerce(v) {
     if (!irange) return +v;

--- a/src/search.js
+++ b/src/search.js
@@ -40,11 +40,12 @@ export function search(data, {
     oninput=${oninput}
   >`;
   const output = html`<output name=output>`;
-  const form = html`<form class=__ns__ onsubmit=${preventDefault} style=${maybeWidth(width)}>
+  const form = html`<form class=__ns__ style=${maybeWidth(width)}>
     ${maybeLabel(label, input)}<div class=__ns__-input>
       ${input}${output}
     </div>${list}
   </form>`;
+  form.addEventListener("submit", preventDefault);
   function oninput() {
     value = input.value || required ? data.filter(filter(input.value)) : [];
     if (columns !== undefined) value.columns = columns;

--- a/src/table.js
+++ b/src/table.js
@@ -249,11 +249,11 @@ function initialize(
     value = undefined; // lazily computed
   }
 
-  root.onscroll = () => {
+  root.addEventListener("scroll", () => {
     if (root.scrollHeight - root.scrollTop < rows * rowHeight * 1.5 && n < minlengthof(n + 1)) {
       appendRows(n, n = minlengthof(n + rows));
     }
-  };
+  });
 
   if (sort === undefined && reverse) {
     materialize();

--- a/src/text.js
+++ b/src/text.js
@@ -19,7 +19,7 @@ export function createText(form, input, value, {
   if (submit) after(button);
   set(input, value);
   value = validate(input) ? get(input) : undefined;
-  form.onsubmit = onsubmit;
+  form.addEventListener("submit", onsubmit);
   input.oninput = oninput;
   function update() {
     if (validate(input)) {

--- a/src/textarea.js
+++ b/src/textarea.js
@@ -1,5 +1,6 @@
 import {html} from "htl";
 import {maybeWidth} from "./css.js";
+import {bubbles} from "./event.js";
 import {maybeLabel} from "./label.js";
 import {createText, onoff, truefalse} from "./text.js";
 
@@ -47,7 +48,7 @@ export function textarea({
   </form>`;
   function onkeydown(event) {
     if (options.submit && event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
-      return form.onsubmit(event);
+      return form.dispatchEvent(new Event("submit", bubbles));
     }
   }
   return createText(form, input, value, options);


### PR DESCRIPTION
Fixes #211.

Also, rather than assigning e.g. form.oninput = …, use form.addEventListener("input", …) so that clients don’t accidentally clobber internal listeners when they want to listen to events. (In other words, reserve the form.oninput = … shorthand for consumers of this API, rather than using it internally.) We still use the shorthand for internal elements, but I’m going to leave that as-is to minimize churn in this PR.