### PR TITLE
accept an array of primitives

### DIFF
--- a/test/inputs/tables.js
+++ b/test/inputs/tables.js
@@ -28,3 +28,11 @@ export function tableCustomHeader() {
 export function tableCustomHeaderHtml() {
   return Inputs.table([{foo: "hello"}], {header: {foo: html`<i>Foo</i>`}});
 }
+
+export function tablePrimitives() {
+  return Inputs.table(["hello", "world", 1, true, false, null]);
+}
+
+export function tableWithNulls() {
+  return Inputs.table([{foo: "hello"}, null, undefined, {foo: 1}]);
+}

--- a/test/output/tablePrimitives.html
+++ b/test/output/tablePrimitives.html
@@ -1,0 +1,37 @@
+<form class="__ns__ __ns__-table" id="__ns__-1" style="max-height: 274px;">
+  <table style="table-layout: fixed;">
+    <thead>
+      <tr>
+        <th><input type="checkbox"></th>
+        <th><span></span>•••</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><input type="checkbox" value="0"></td>
+        <td>hello</td>
+      </tr>
+      <tr>
+        <td><input type="checkbox" value="1"></td>
+        <td>world</td>
+      </tr>
+      <tr>
+        <td><input type="checkbox" value="2"></td>
+        <td>1</td>
+      </tr>
+      <tr>
+        <td><input type="checkbox" value="3"></td>
+        <td>true</td>
+      </tr>
+      <tr>
+        <td><input type="checkbox" value="4"></td>
+        <td>false</td>
+      </tr>
+      <tr>
+        <td><input type="checkbox" value="5"></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <style></style>
+</form>

--- a/test/output/tableWithNulls.html
+++ b/test/output/tableWithNulls.html
@@ -1,0 +1,29 @@
+<form class="__ns__ __ns__-table" id="__ns__-1" style="max-height: 274px;">
+  <table style="table-layout: fixed;">
+    <thead>
+      <tr>
+        <th><input type="checkbox"></th>
+        <th title="foo"><span></span>foo</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><input type="checkbox" value="0"></td>
+        <td>hello</td>
+      </tr>
+      <tr>
+        <td><input type="checkbox" value="1"></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><input type="checkbox" value="2"></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td><input type="checkbox" value="3"></td>
+        <td>1</td>
+      </tr>
+    </tbody>
+  </table>
+  <style></style>
+</form>


### PR DESCRIPTION
we continue to ignore nullish values when collecting column names, so that when a table has a few nulls in an array of key-value objects, we don't create a spurious column.

fixes #160

todo: maybe gray out the booleans w/ #214?