### PR TITLE
Support non-ascii characters in search

### DIFF
--- a/src/search.js
+++ b/src/search.js
@@ -117,7 +117,7 @@ function* valuesof(d) {
 }
 
 function termFilter(term) {
-  return new RegExp(`\\b${escapeRegExp(term)}`, "i");
+  return new RegExp(`\(?<!\S)${escapeRegExp(term)}`, "i");
 }
 
 function escapeRegExp(text) {

--- a/src/search.js
+++ b/src/search.js
@@ -117,7 +117,7 @@ function* valuesof(d) {
 }
 
 function termFilter(term) {
-  return new RegExp(`\(?<!\S)${escapeRegExp(term)}`, "i");
+  return new RegExp(`(?:^|\\s)${escapeRegExp(term)}`, "i");
 }
 
 function escapeRegExp(text) {

--- a/src/search.js
+++ b/src/search.js
@@ -117,7 +117,7 @@ function* valuesof(d) {
 }
 
 function termFilter(term) {
-  return new RegExp(`(?:^|\\s)${escapeRegExp(term)}`, "i");
+  return new RegExp(`(?:^|[^\\p{L}-])${escapeRegExp(term)}`, "iu");
 }
 
 function escapeRegExp(text) {

--- a/test/inputs/searches.js
+++ b/test/inputs/searches.js
@@ -17,6 +17,10 @@ export async function searchLabelQuery() {
   return Inputs.search(["red", "green", "blue", "black"], {label: "colors", query: "bl"});
 }
 
+export async function searchLabelQueryCyrillic() {
+  return Inputs.search(["red", "green", "blue", "чёрный"], {label: "colors", query: "чёрн"});
+}
+
 export async function searchPlaceholder() {
   return Inputs.search(["red", "green", "blue"], {placeholder: "dollars&pounds"});
 }

--- a/test/output/searchLabelQueryCyrillic.html
+++ b/test/output/searchLabelQueryCyrillic.html
@@ -1,0 +1,6 @@
+<form class="__ns__">
+  <label for="__ns__-1">colors</label>
+  <div class="__ns__-input">
+    <input name="input" type="search" placeholder="Search" value="чёрн" id="__ns__-1"><output name="output">1 result</output>
+  </div>
+</form>

--- a/test/search-test.js
+++ b/test/search-test.js
@@ -3,8 +3,8 @@ import assert from "assert";
 import it from "./jsdom.js";
 
 it("Inputs.search(data) handles word boundaries", () => {
-  const s = Inputs.search(["red", "green", "blue", "The Real"], {query: "re"});
-  assert.deepStrictEqual(s.value, ["red", "The Real"]);
+  const s = Inputs.search(["red", "blue", "The Real", "Mr.Real", "un-real"], {query: "re"});
+  assert.deepStrictEqual(s.value, ["red", "The Real", "Mr.Real"]);
 });
 
 it("Inputs.search(data) supports Cyrillic symbols", () => {

--- a/test/search-test.js
+++ b/test/search-test.js
@@ -1,0 +1,13 @@
+import * as Inputs from "@observablehq/inputs";
+import assert from "assert";
+import it from "./jsdom.js";
+
+it("Inputs.search(data) handles word boundaries", () => {
+  const s = Inputs.search(["red", "green", "blue", "The Real"], {query: "re"});
+  assert.deepStrictEqual(s.value, ["red", "The Real"]);
+});
+
+it("Inputs.search(data) supports Cyrillic symbols", () => {
+  const s = Inputs.search(["red", "дом", "чудо", "Река Дон"], {query: "до"});
+  assert.deepStrictEqual(s.value, ["дом", "Река Дон"]);
+});


### PR DESCRIPTION
`Inputs.search` does not work with Cyrillic queries due to the problem with the word boundary assertion (`\b`). It supports only latin symbols:

![image](https://user-images.githubusercontent.com/642673/155751542-29b328b1-03a2-4cd0-af3d-cd08f1c7d7fc.png)


This PR introduces negative lookbehind `(?<!\S)` instead of `\b` to detect a word
boundary.
