### PR TITLE
Fix labels overflowing

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -24,6 +24,8 @@ form.__ns__ {
 form.__ns__ > label {
   width: 100%;
   padding-bottom: 3px;
+  text-overflow: ellipsis;
+  overflow: hidden;
 }
 
 /* On narrow screens, a toggle is small enough to fit inline with the label;


### PR DESCRIPTION
Fixes nonwrapping widget labels bleeding into other elements.

**Before / after:**
<img width=400 src=https://user-images.githubusercontent.com/322014/195549471-c9c1e275-3e3a-4ddc-9e0c-d8175209e1ad.png> <img width=400 src=https://user-images.githubusercontent.com/322014/195549585-4cc8fcbd-efd3-4632-95a3-47ccadf6aa0b.png>

**Before / after:**
<img width=400 src=https://user-images.githubusercontent.com/322014/195550024-fd5e677c-bfbc-4e57-bbad-3cf4bafa038b.png> <img width=400 src=https://user-images.githubusercontent.com/322014/195550354-da2f4ac9-dbf1-4851-aa0d-5de46cd1d15d.png>

