### PR TITLE
Remove negative table margin

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -205,7 +205,6 @@ form.__ns__-checkbox {
 form.__ns__-table {
   display: block;
   overflow-y: auto;
-  margin: 0 -14px;
   width: 100%;
 }
 


### PR DESCRIPTION
The Inputs.table has a -14px horizontal margin which makes it not align with the notebook's cell borders. See [this notebook](https://observablehq.com/d/3624b95610a527e4) to see the result of this change (using a file attachment version of Inputs with the -14px removed).

<img width="1245" alt="image" src="https://github.com/observablehq/inputs/assets/10869236/5c5a9d1a-ebb0-44d2-b92b-2d93cc0480f1">

This is also causing issues when someone exports a table cell where it is too far to the left.

<img width="1201" alt="image" src="https://github.com/observablehq/inputs/assets/10869236/7b34254d-8c19-4ff7-8b4c-2e623c2c971a">
