### PR TITLE
expose file type, lastModified

### DIFF
--- a/src/file.js
+++ b/src/file.js
@@ -7,7 +7,7 @@ export function fileOf(AbstractFile) {
 
   class LocalFile extends AbstractFile {
     constructor(file) {
-      super(file.name);
+      super(file.name, file.type, file.lastModified);
       Object.defineProperty(this, "_", {value: file});
       Object.defineProperty(this, "_url", {writable: true});
     }


### PR DESCRIPTION
These aren’t used by the standard library in notebooks (yet), but Framework will use them.

https://github.com/observablehq/framework/blob/60ff015673730a8f21ea74cef22b8ed3b981782e/src/client/stdlib/fileAttachment.js#L28

See [type](https://w3c.github.io/FileAPI/#dfn-type) and [lastModified](https://w3c.github.io/FileAPI/#dfn-lastModified).