### PR TITLE
Center position of arrow glyph in table headings

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -231,6 +231,7 @@ form.__ns__-table {
   display: inline-block;
   width: 0.5em;
   margin-left: -0.5em;
+  padding-right: 0.25em;
 }
 
 .__ns__-table td,

--- a/src/style.css
+++ b/src/style.css
@@ -228,10 +228,10 @@ form.__ns__-table {
 }
 
 .__ns__-table thead th span {
-  display: inline-block;
+  display: inline-flex;
+  justify-content: center;
   width: 0.5em;
   margin-left: -0.5em;
-  padding-right: 0.25em;
 }
 
 .__ns__-table td,


### PR DESCRIPTION
Closes #267.

![image](https://github.com/user-attachments/assets/6dcb4fd6-90f8-406d-a5ea-88cc568b93ea)
